### PR TITLE
Adds a version constraint for Sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ home-page = 'https://github.com/kalekundert/autoclasstoc'
 description-file = 'README.rst'
 requires-python = "~=3.7"
 requires = [
-  'sphinx',
+  'sphinx~=3.0',
   'docutils',
 ]
 classifiers = [


### PR DESCRIPTION
as sphinx.util.docstrings.extract_metadata isn't available in
previous releases.