### PR TITLE
Adds testing for Python 3.6 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: python
 
 python:
+    - "3.6"
     - "3.7"
+    - "3.8"
 
 # In order for coverage to work, the package needs to be installed in editable/
-# symlink mode.  Unfortunately, this means we can't use pip to install the 
-# package (as of version 19.2), because pip cannot use `pyproject.toml` for 
-# editable installs.  Instead it requires `setup.py`, which we don't have.  
+# symlink mode.  Unfortunately, this means we can't use pip to install the
+# package (as of version 19.2), because pip cannot use `pyproject.toml` for
+# editable installs.  Instead it requires `setup.py`, which we don't have.
 # This means we need to use `flit` directly to install the package.
 install:
     - pip install -U flit flit coverage pytest pytest-cov python-coveralls
     - flit install --symlink
 
-script: 
+script:
     - py.test tests --cov autoclasstoc
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ python:
 # editable installs.  Instead it requires `setup.py`, which we don't have.
 # This means we need to use `flit` directly to install the package.
 install:
-    - pip install -U flit flit coverage pytest pytest-cov python-coveralls
+    - pip install flit pytest-cov python-coveralls
     - flit install --symlink
 
 script:
-    - py.test tests --cov autoclasstoc
+    - pytest tests --cov autoclasstoc
 
 after_success:
     - coveralls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "Kale Kundert"
 author-email = "kale@thekunderts.net"
 home-page = 'https://github.com/kalekundert/autoclasstoc'
 description-file = 'README.rst'
-requires-python = "~=3.7"
+requires-python = "~=3.6"
 requires = [
   'sphinx~=3.0',
   'docutils',
@@ -22,5 +22,3 @@ classifiers = [
 'Documentation' = 'https://autoclasstoc.readthedocs.io/en/latest/'
 'Version Control' = 'https://github.com/kalekundert/autoclasstoc'
 'Bug Tracker' = 'https://github.com/kalekundert/autoclasstoc/issues'
-
-


### PR DESCRIPTION
i also checked the results of a build w/ Python 3.6 locally. (3.6. will be maintained until the end of the next year.)

i'd be great if you also released a new patch release when this was incorporated to allow installing `autoclasstoc` into envitonments that are constrained to Python 3.6.