### PR TITLE
chore: Update to run on Python 3.6 to Python 3.10.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,18 @@ author = "Kale Kundert"
 author-email = "kale@thekunderts.net"
 home-page = 'https://github.com/kalekundert/autoclasstoc'
 description-file = 'README.rst'
-requires-python = "~=3.6"
+requires-python = ">=3.6,<3.11"
 requires = [
   'sphinx>=3.0',
   'docutils',
 ]
 classifiers = [
   'Programming Language :: Python :: 3',
+  'Programming Language :: Python :: 3.6',
+  'Programming Language :: Python :: 3.7',
+  'Programming Language :: Python :: 3.8',
+  'Programming Language :: Python :: 3.9',
+  'Programming Language :: Python :: 3.10',
   'License :: OSI Approved :: MIT License',
 ]
 


### PR DESCRIPTION
G'day mate.

Updates to pyproject.toml:

I have updated the python requires so autoclasstoc can run on up to Python 3.10.
I have updated the Trove classifiers to reflect the Python versions.

I have tested locally using Tox for all the Python versions listed.

  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  py3.10: commands succeeded
  py38pypy: commands succeeded
  py39-docs: commands succeeded
  congratulations :)

cheers