### PR TITLE
Remove useless shebang lines

### DIFF
--- a/autoclasstoc/__init__.py
+++ b/autoclasstoc/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """\
 Add a succinct TOC to auto-documented classes.
 """

--- a/autoclasstoc/errors.py
+++ b/autoclasstoc/errors.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 class AutoClassTocError(Exception):
     pass
 

--- a/autoclasstoc/nodes.py
+++ b/autoclasstoc/nodes.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """\
 The :mod:`autoclasstoc` module defines two new *docutils* nodes, which make it 
 possible to create collapsible content in HTML.

--- a/autoclasstoc/plugin.py
+++ b/autoclasstoc/plugin.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from sphinx.util.docutils import SphinxDirective
 from . import utils, __version__, ConfigError
 

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import inspect
 from docutils import nodes as _nodes
 from . import utils

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from docutils import nodes as _nodes
 from docutils.statemachine import StringList, string2lines
 from importlib import import_module

--- a/docs/_ext/example.py
+++ b/docs/_ext/example.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.util.docutils import ReferenceRole

--- a/docs/_ext/show_nodes.py
+++ b/docs/_ext/show_nodes.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from docutils import nodes
 from docutils.parsers.rst import Directive
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import pytest
 import autoclasstoc
 


### PR DESCRIPTION
These sources are not script-like (have no “`if __name__ == '__main__'`” or similar) and do not have the executable bit set, so the shebang lines are not useful.