### PR TITLE
Add `exclude_pattern` to `Section` class

### DIFF
--- a/autoclasstoc/nodes.py
+++ b/autoclasstoc/nodes.py
@@ -7,6 +7,7 @@ possible to create collapsible content in HTML.
 
 from docutils.nodes import General, Element, TextElement
 
+
 class details(General, Element):
     """
     A node that can be expanded or collapsed by the user.
@@ -21,12 +22,12 @@ class details(General, Element):
 
     def visit_html(visitor, node):
         atts = {
-                'class': ' '.join(node['classes'])
+            'class': ' '.join(node['classes'])
         }
         parts = ['details'] + [
-                f'{k}="{v}"'
-                for k, v in atts.items()
-                if v
+            f'{k}="{v}"'
+            for k, v in atts.items()
+            if v
         ]
         if node['open']:
             parts += 'open'
@@ -37,6 +38,7 @@ class details(General, Element):
         visitor.body.append('</details>')
 
     html = visit_html, depart_html
+
 
 class details_summary(General, TextElement):
     """
@@ -54,16 +56,16 @@ class details_summary(General, TextElement):
 
     html = visit_html, depart_html
 
+
 def setup(app):
     """
     Configure Sphinx to use the `details` and `details_summary` nodes.
     """
     app.add_node(
-            details,
-            html=details.html,
+        details,
+        html=details.html,
     )
     app.add_node(
-            details_summary,
-            html=details_summary.html,
+        details_summary,
+        html=details_summary.html,
     )
-

--- a/autoclasstoc/plugin.py
+++ b/autoclasstoc/plugin.py
@@ -3,6 +3,7 @@
 from sphinx.util.docutils import SphinxDirective
 from . import utils, __version__, ConfigError
 
+
 class AutoClassToc(SphinxDirective):
     """
     Generate a succinct TOC for automatically documented classes.
@@ -14,8 +15,8 @@ class AutoClassToc(SphinxDirective):
     """
     optional_arguments = 1
     option_spec = {
-            'sections': utils.comma_separated_list,
-            'exclude-sections': utils.comma_separated_list,
+        'sections': utils.comma_separated_list,
+        'exclude-sections': utils.comma_separated_list,
     }
 
     def run(self):
@@ -27,13 +28,15 @@ class AutoClassToc(SphinxDirective):
             mod_name, cls_name = utils.pick_class(qual_name, self.env)
             mod, cls = utils.load_class(mod_name, cls_name)
             sections = utils.pick_sections(
-                    self.options.get('sections') or self.config.autoclasstoc_sections,
-                    exclude=self.options.get('exclude-sections'),
+                self.options.get('sections') or
+                self.config.autoclasstoc_sections,
+                exclude=self.options.get('exclude-sections'),
             )
             return utils.make_toc(self.state, cls, sections)
 
         except ConfigError as err:
             raise self.error(str(err))
+
 
 def load_static_assets(app, config):
     """
@@ -48,15 +51,16 @@ def load_static_assets(app, config):
 
     app.add_css_file('autoclasstoc.css')
 
+
 def setup(app):
     from . import nodes
     nodes.setup(app)
 
     default_sections = [
-            'public-attrs',
-            'public-methods',
-            'private-attrs',
-            'private-methods'
+        'public-attrs',
+        'public-methods',
+        'private-attrs',
+        'private-methods'
     ]
 
     app.add_config_value('autoclasstoc_sections', default_sections, 'env')
@@ -64,9 +68,6 @@ def setup(app):
     app.connect('config-inited', load_static_assets)
 
     return {
-            'version': __version__,
-            'parallel_read_safe': True,
+        'version': __version__,
+        'parallel_read_safe': True,
     }
-
-
-

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -246,6 +246,14 @@ class PublicMethods(Section):
         )
 
 
+class PublicMethodsWithoutDunders(PublicMethods):
+    """
+    Include a "Public Methods" section in the class TOC.
+    """
+    key = 'public-methods-without-dunders'
+    exclude_pattern = '__'
+
+
 class PrivateMethods(Section):
     """
     Include a "Private Methods" section in the class TOC.

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -6,6 +6,7 @@ from . import utils
 
 SECTIONS = {}
 
+
 class Section:
     """
     Format a specific section in a class TOC, e.g. "Public Methods".
@@ -32,7 +33,7 @@ class Section:
     :rst:dir:`autoclasstoc` options such as ``:sections:`` and 
     ``:exclude-sections:``.
     """
-    
+
     title = None
     """
     The text that will be used to label this section.
@@ -76,9 +77,11 @@ class Section:
         e.g. if it doesn't have a title specified.
         """
         if not self.key:
-            raise ConfigError(f"no key specified for {self.__class__.__name__!r}")
+            raise ConfigError(
+                f"no key specified for {self.__class__.__name__!r}")
         if not self.title:
-            raise ConfigError(f"no title specified for {self.__class__.__name__!r}")
+            raise ConfigError(
+                f"no title specified for {self.__class__.__name__!r}")
 
     def format(self):
         """
@@ -93,8 +96,8 @@ class Section:
 
         attrs = self._filter_attrs(self._find_attrs())
         inherited_attrs = {
-                parent: self._filter_attrs(attrs)
-                for parent, attrs in self._find_inherited_attrs().items()
+            parent: self._filter_attrs(attrs)
+            for parent, attrs in self._find_inherited_attrs().items()
         }
 
         if not attrs and not any(inherited_attrs.values()):
@@ -212,7 +215,7 @@ class Section:
     def _find_attrs(self):
         """
         Return all attributes associated with this class.
-        
+
         These attributes will subsequently be filtered to remove any that 
         aren't relevant to this section, so there is no need to do any 
         filtering here.  The return value should be a name-to-attribute 
@@ -230,6 +233,7 @@ class Section:
         class types to :attr:`__dict__` style dictionaries.
         """
         return utils.find_inherited_attrs(self.cls)
+
 
 class PublicMethods(Section):
     """
@@ -327,6 +331,7 @@ def is_method(name, attr):
         inspect.ismethoddescriptor(attr),
     ])
 
+
 def is_data_attr(name, attr, exclude_special=True):
     """
     Return true if the given attribute is a data attribute, e.g. not a method 
@@ -346,6 +351,7 @@ def is_data_attr(name, attr, exclude_special=True):
         not inspect.ismethoddescriptor(attr),
     ])
 
+
 def is_public(name):
     """
     Return true if the given name is public.
@@ -356,6 +362,7 @@ def is_public(name):
     """
     return not name.startswith('_') or is_special(name)
 
+
 def is_private(name):
     """
     Return true if the given name is private.
@@ -365,6 +372,7 @@ def is_private(name):
     """
     return not is_public(name)
 
+
 def is_special(name):
     """
     Return True if the name starts and ends with a double-underscore.
@@ -372,4 +380,3 @@ def is_special(name):
     Such names typically have special meaning to Python, e.g. :meth:`__init__`.
     """
     return name.startswith('__') and name.endswith('__')
-

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -129,10 +129,10 @@ class Section:
         Return true if the given :attr:`name` matches the 
         :attr:`~.exclude_pattern`
         """
-        if exclude_pattern:
-            return any(re.search(p, name) for p in exclude_pattern)
-        else:
-            return False
+        return (
+            exclude_pattern and
+            any(re.search(p, name) for p in exclude_pattern)
+        )
 
     def predicate(self, name, attr, meta):
         """

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -131,6 +131,8 @@ class Section:
         """
         if exclude_pattern:
             return any(re.search(p, name) for p in exclude_pattern)
+        else:
+            return False
 
     def predicate(self, name, attr, meta):
         """

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -45,6 +45,11 @@ class Section:
     Whether or not to include inherited attributes in this section.
     """
 
+    exclude_pattern = None
+    """
+    Whether to exclude attributes where the name of it matches the pattern
+    """
+
     def __init__(self, state, cls):
         """
         Create a section for a specific class.
@@ -113,6 +118,17 @@ class Section:
             wrapper += d
 
         return [wrapper]
+
+    def check_for_pattern(self, name):
+        """
+        Return true if the given :attr:`name` matches the 
+        :attr:`~.exclude_pattern`
+        """
+        if exclude_pattern:
+            return any(
+                re.match(p, name)
+                for p in always_iterable(self.exclude_pattern)
+            )
 
     def predicate(self, name, attr, meta):
         """
@@ -223,7 +239,11 @@ class PublicMethods(Section):
     title = "Public Methods:"
 
     def predicate(self, name, attr, meta):
-        return is_method(name, attr) and is_public(name)
+        return (
+            self.check_for_pattern(name) and
+            is_method(name, attr) and
+            is_public(name)
+        )
 
 
 class PrivateMethods(Section):
@@ -234,7 +254,12 @@ class PrivateMethods(Section):
     title = "Private Methods:"
 
     def predicate(self, name, attr, meta):
-        return is_method(name, attr) and is_private(name)
+        return (
+            self.check_for_pattern(name) and
+            is_method(name, attr) and
+            is_private(name)
+        )
+
 
 class PublicDataAttrs(Section):
     """
@@ -248,7 +273,12 @@ class PublicDataAttrs(Section):
     title = "Public Data Attributes:"
 
     def predicate(self, name, attr, meta):
-        return is_data_attr(name, attr) and is_public(name)
+        return (
+            self.check_for_pattern(name) and
+            is_data_attr(name, attr) and
+            is_public(name)
+        )
+
 
 class PrivateDataAttrs(Section):
     """
@@ -262,7 +292,12 @@ class PrivateDataAttrs(Section):
     title = "Private Data Attributes:"
 
     def predicate(self, name, attr, meta):
-        return is_data_attr(name, attr) and is_private(name)
+        return (
+            self.check_for_pattern(name) and
+            is_data_attr(name, attr) and
+            is_private(name)
+        )
+
 
 class InnerClasses(Section):
     """
@@ -272,7 +307,8 @@ class InnerClasses(Section):
     title = "Inner Classes:"
 
     def predicate(self, name, attr, meta):
-        return inspect.isclass(attr)
+        return self.check_for_pattern(name) and inspect.isclass(attr)
+
 
 def is_method(name, attr):
     """

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -3,6 +3,7 @@
 import inspect
 from docutils import nodes as _nodes
 from . import utils
+import re
 
 SECTIONS = {}
 
@@ -127,11 +128,10 @@ class Section:
         Return true if the given :attr:`name` matches the 
         :attr:`~.exclude_pattern`
         """
-        if exclude_pattern:
+        if self.exclude_pattern:
             return any(
-                re.match(p, name)
-                for p in always_iterable(self.exclude_pattern)
-            )
+                re.search(p, name)
+                for p in self.exclude_pattern)
 
     def predicate(self, name, attr, meta):
         """

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -129,9 +129,7 @@ class Section:
         :attr:`~.exclude_pattern`
         """
         if self.exclude_pattern:
-            return any(
-                re.search(p, name)
-                for p in self.exclude_pattern)
+            return any(re.search(p, name) for p in self.exclude_pattern)
 
     def predicate(self, name, attr, meta):
         """

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -123,13 +123,14 @@ class Section:
 
         return [wrapper]
 
-    def check_for_pattern(self, name):
+    @staticmethod
+    def exclude_if_match(exclude_pattern, name):
         """
         Return true if the given :attr:`name` matches the 
         :attr:`~.exclude_pattern`
         """
-        if self.exclude_pattern:
-            return any(re.search(p, name) for p in self.exclude_pattern)
+        if exclude_pattern:
+            return any(re.search(p, name) for p in exclude_pattern)
 
     def predicate(self, name, attr, meta):
         """
@@ -242,7 +243,7 @@ class PublicMethods(Section):
 
     def predicate(self, name, attr, meta):
         return (
-            self.check_for_pattern(name) and
+            not self.exclude_if_match(self.exclude_pattern, name) and
             is_method(name, attr) and
             is_public(name)
         )
@@ -265,7 +266,7 @@ class PrivateMethods(Section):
 
     def predicate(self, name, attr, meta):
         return (
-            self.check_for_pattern(name) and
+            not self.exclude_if_match(self.exclude_pattern, name) and
             is_method(name, attr) and
             is_private(name)
         )
@@ -284,7 +285,7 @@ class PublicDataAttrs(Section):
 
     def predicate(self, name, attr, meta):
         return (
-            self.check_for_pattern(name) and
+            not self.exclude_if_match(self.exclude_pattern, name) and
             is_data_attr(name, attr) and
             is_public(name)
         )
@@ -303,7 +304,7 @@ class PrivateDataAttrs(Section):
 
     def predicate(self, name, attr, meta):
         return (
-            self.check_for_pattern(name) and
+            not self.exclude_if_match(self.exclude_pattern, name) and
             is_data_attr(name, attr) and
             is_private(name)
         )
@@ -317,7 +318,10 @@ class InnerClasses(Section):
     title = "Inner Classes:"
 
     def predicate(self, name, attr, meta):
-        return self.check_for_pattern(name) and inspect.isclass(attr)
+        return (
+            not self.exclude_if_match(self.exclude_pattern, name) and
+            inspect.isclass(attr)
+        )
 
 
 def is_method(name, attr):

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -5,6 +5,7 @@ from docutils.statemachine import StringList, string2lines
 from importlib import import_module
 from .errors import ConfigError
 
+
 def pick_class(qual_name, env):
     """
     Figure out which class to make the TOC for.
@@ -15,25 +16,28 @@ def pick_class(qual_name, env):
 
     Arguments:
         qual_name (str): The name of the class to pick, or None if the class 
-            should be inferred from the environment.
+        should be inferred from the environment.
         env (sphinx.environment.BuildEnvironment): This object is available as 
-            :attr:`self.env` from :class:`~sphinx.util.docutils.SphinxDirective` 
-            subclasses.
+        :attr:`self.env` from :class:`~sphinx.util.docutils.SphinxDirective` 
+        subclasses.
     """
     if qual_name:
         mod_name, cls_name = qual_name.rsplit('.', 1)
     else:
         cls_name = \
-                env.temp_data.get('autodoc:class') or \
-                env.ref_context.get('py:class')
+            env.temp_data.get('autodoc:class') or \
+            env.ref_context.get('py:class')
         mod_name = \
-                env.temp_data.get('autodoc:module') or \
-                env.ref_context.get('py:module')
+            env.temp_data.get('autodoc:module') or \
+            env.ref_context.get('py:module')
 
-        if not cls_name: raise ConfigError("no class name")
-        if not mod_name: raise ConfigError("no module name")
+        if not cls_name:
+            raise ConfigError("no class name")
+        if not mod_name:
+            raise ConfigError("no module name")
 
     return mod_name, cls_name
+
 
 def load_class(mod_name, cls_name):
     """
@@ -42,6 +46,7 @@ def load_class(mod_name, cls_name):
     mod = import_module(mod_name)
     cls = getattr(mod, cls_name)
     return mod, cls
+
 
 def pick_sections(sections, exclude=None):
     """
@@ -68,18 +73,19 @@ def pick_sections(sections, exclude=None):
         raise ConfigError(f"cannot interpret {x!r} as a section")
 
     sections = [
-            _section_from_anything(x)
-            for x in sections
+        _section_from_anything(x)
+        for x in sections
     ]
     exclude = {
-            _section_from_anything(x)
-            for x in exclude or []
+        _section_from_anything(x)
+        for x in exclude or []
     }
     return [
-            x
-            for x in sections
-            if x not in exclude
+        x
+        for x in sections
+        if x not in exclude
     ]
+
 
 def make_toc(state, cls, sections):
     """
@@ -94,6 +100,7 @@ def make_toc(state, cls, sections):
     n.append(_nodes.transition())
     return n
 
+
 def make_container():
     """
     Make a container node to identify elements associated with the 
@@ -101,11 +108,13 @@ def make_container():
     """
     return _nodes.container(classes=['autoclasstoc'])
 
+
 def make_rubric(title):
     """
     Make an informal header.
     """
     return _nodes.rubric(title, title)
+
 
 def make_inherited_details(state, parent, open_by_default=False):
     """
@@ -113,11 +122,13 @@ def make_inherited_details(state, parent, open_by_default=False):
     """
     from .nodes import details, details_summary
     s = details_summary()
-    s += strip_p(nodes_from_rst(state, f"Inherited from :py:class:`{parent.__qualname__}`"))
+    s += strip_p(nodes_from_rst(state,
+                                f"Inherited from    : py: class:`{parent.__qualname__}`"))
 
     d = details(open_by_default)
     d += s
     return d
+
 
 def make_links(state, attrs):
     """
@@ -133,16 +144,18 @@ def make_links(state, attrs):
         *[f'    {x}' for x in attrs],
     ])
 
+
 def find_inherited_attrs(cls):
     """
     Return a dictionary mapping parent classes to the attributes inherited from 
     those classes.
     """
     return {
-            base: base.__dict__
-            for base in cls.__mro__
-            if base not in (cls, object)
+        base: base.__dict__
+        for base in cls.__mro__
+        if base not in (cls, object)
     }
+
 
 def filter_attrs(attrs, predicate):
     """
@@ -152,10 +165,11 @@ def filter_attrs(attrs, predicate):
     from sphinx.util.docstrings import extract_metadata
 
     return {
-            k: v
-            for k, v in attrs.items()
-            if predicate(k, v, extract_metadata(getdoc(v)))
+        k: v
+        for k, v in attrs.items()
+        if predicate(k, v, extract_metadata(getdoc(v)))
     }
+
 
 def nodes_from_rst(state, rst):
     """
@@ -180,12 +194,13 @@ def nodes_from_rst(state, rst):
     state.nested_parse(rst, 0, wrapper)
     return wrapper.children
 
+
 def strip_p(nodes):
     """
     Remove any top-level paragraph nodes.
 
     Parsing a simple string like "Hello world" with `nodes_from_rst` will 
-    return text wrapped in a paragraph.  If this paragraph is not desired (e.g. 
+    return text wrapped in a paragraph.  If this paragraph is not desired (e.g.  
     because it messes with formatting), this function can be used to get rid of 
     it.
     """
@@ -193,10 +208,9 @@ def strip_p(nodes):
         nodes = nodes[0].children
     return nodes
 
+
 def comma_separated_list(x):
     """
     Parse a restructured text option as a comma-separated list of strings.
     """
     return x.split(',')
-
-

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -143,6 +143,52 @@ Finally, we need to specify that our new sections should be used by default
           'private-methods',
   ]
 
+Based on pattern
+----------------
+Categorizing attributes based on some pattern in their names is convenient, 
+because it doesn't require making any changes or annotations to the code 
+itself. For this example, we'll make a custom "Public Methods" section that 
+will consist of public methods but excluding all "dunders" methods , e.g.  
+:meth:`__init__()`.
+
+The first step is to define a new `PublicSection` subclass with the following 
+attributes:
+
+- :attr:`~autoclasstoc.Section.key`: used to include or exclude the section 
+  from class TOCs.
+
+- :attr:`~autoclasstoc.Section.exclude_pattern`:  used for regex matching of 
+  the name for exclusion
+
+.. code-block::
+  :caption: conf.py
+
+  from autoclasstoc import PublicSection, is_method
+
+  class PublicMethodsWithoutDunders(PublicSection):
+      exclude_pattern = '__'
+      key = 'public-methods-without-dunders'
+
+
+No more is necessary because the `PublicSection` (and all other `Section` 
+subclasses) check for possible `exclude_pattern`. Note here, that 
+`exclude_pattern` can also be a list of strings.
+
+Finally, we need to specify that our new sections should be used by default 
+(and what order they should go in):
+
+.. code-block::
+  :caption: conf.py
+
+  autoclasstoc_sections = [
+          'public-methods-without-dunders',
+          'private-methods',
+  ]
+
+This class we just created (`PublicMethodsWithoutDunders`) is already within 
+:rst:dir:`autoclasstoc`. It can be used with the key 
+`public-methods-without-dunders` in the `autoclasstoc_sections` variable.
+
 Based on decorator
 ------------------
 A more explicit way to categorize methods is to use a decorator to label 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -10,7 +10,7 @@ A TOC for every class
 It is also possible to use :rst:dir:`autoclasstoc` in auto-generated API 
 documentation, i.e. where all of the classes in your project are documented 
 without you having to explicitly write an :rst:dir:`autoclass` directive for 
-each one.  The way to do this is to use the :ext:`autosummary` extension with a 
+each one. The way to do this is to use the :ext:`autosummary` extension with a 
 custom Jinja template for classes, as detailed below:
 
 1. Configure the :ext:`autosummary` extension to automatically generate stub 
@@ -22,7 +22,7 @@ custom Jinja template for classes, as detailed below:
       autosummary_generate = True
 
    Alternatively, you could generate stub files yourself by running the 
-   ``autogen`` command when necessary (after completing steps 2 and 3 below).  
+   ``autogen`` command when necessary (after completing steps 2 and 3 below). 
    I find this less convenient, but it might be better if you intend to edit 
    the stub files by hand:
 
@@ -31,7 +31,7 @@ custom Jinja template for classes, as detailed below:
       $ sphinx-autogen -t _templates path/to/doc/with/autosummary.rst
 
 2. Add an :rst:dir:`autosummary` directive with the ``:toctree:`` and 
-   ``:recursive:`` options to your documentation.  Anywhere will work, but 
+   ``:recursive:`` options to your documentation. Anywhere will work, but 
    ``index.rst`` is a common choice:
 
    .. code-block:: rst
@@ -43,7 +43,7 @@ custom Jinja template for classes, as detailed below:
 
          module.to.document
 
-3. Provide a custom Jinja_ template for formatting class stub files.  The 
+3. Provide a custom Jinja_ template for formatting class stub files. The 
    purpose of this template is to specify that :rst:dir:`autoclasstoc` should 
    be used for each class:
 
@@ -72,10 +72,10 @@ custom Jinja template for classes, as detailed below:
 Custom sections
 ===============
 By default, :rst:dir:`autoclasstoc` divides the TOC into sections based whether 
-or not attributes are methods, and whether or not they are public.  This is a 
+or not attributes are methods, and whether or not they are public. This is a 
 reasonable default, but for many projects it may make sense to add custom 
-sections specific to the idioms of that project.  Fortunately, this is easy to 
-configure.  The basic steps are:
+sections specific to the idioms of that project. Fortunately, this is easy to 
+configure. The basic steps are:
 
 1. Define new :class:`autoclasstoc.Section` subclasses.
 2. Reference the subclasses either in ``conf.py`` or in the documentation 
@@ -83,13 +83,13 @@ configure.  The basic steps are:
   
 This approach is very powerful, because the `Section` class controls all 
 aspects of defining and formatting the TOC sections, and its subclasses can 
-overwrite any of that behavior.  Below are some specific examples showing how 
+overwrite any of that behavior. Below are some specific examples showing how 
 custom sections can be configured:
 
 Based on name
 -------------
 Categorizing attributes based on their names is convenient, because it doesn't 
-require making any changes or annotations to the code itself.  For this 
+require making any changes or annotations to the code itself. For this 
 example, we'll make a custom "Event Handlers" section that will consist of 
 methods that begin with the prefix "on\_", e.g. :meth:`on_mouse_down()` or 
 :meth:`on_key_up()`.
@@ -192,9 +192,9 @@ This class we just created (`PublicMethodsWithoutDunders`) is already within
 Based on decorator
 ------------------
 A more explicit way to categorize methods is to use a decorator to label 
-methods that belong to a particular section.  This approach only is only 
+methods that belong to a particular section. This approach only is only 
 applicable to methods and inner classes (because data attributes cannot be 
-decorated), but is easy to implement.  For this example, we'll make a section 
+decorated), but is easy to implement. For this example, we'll make a section 
 for "Read Only" methods that are identified by a decorator:
 
 The first step is to write a decorator to label read-only methods:
@@ -247,8 +247,8 @@ With :ext:`autodoc`, it's possible to describe how an object should be
 documented by including `:meta: <info-field-lists>` fields in that object's 
 docstring.  :rst:dir:`autoclasstoc` automatically parses these fields and 
 provides them as an argument to :meth:`~autoclasstoc.Section.predicate()`, so 
-they can be easily used to categorize attributes.  As in the previous example, 
-we'll make a custom section for read-only methods.  The snippet below shows how 
+they can be easily used to categorize attributes. As in the previous example, 
+we'll make a custom section for read-only methods. The snippet below shows how 
 such a method might be identified using a meta field:
 
 .. code-block:: python
@@ -264,7 +264,7 @@ such a method might be identified using a meta field:
           pass
 
 These meta fields are parsed into a dictionary such that ``:meta key: value`` 
-would give ``{'key': 'value'}``.  This dictionary is provided to the 
+would give ``{'key': 'value'}``. This dictionary is provided to the 
 :meth:`~autoclasstoc.Section.predicate()` method via the *meta* argument:
 
 .. code-block:: python
@@ -294,8 +294,8 @@ would give ``{'key': 'value'}``.  This dictionary is provided to the
 Custom CSS
 ==========
 All of the HTML elements generated by :rst:dir:`autoclasstoc` are contained in 
-a ``<div>`` with class ``autoclasstoc``.  This can be used to select and style 
-the elements in the class TOC.  Note that the plugin includes some default 
+a ``<div>`` with class ``autoclasstoc``. This can be used to select and style 
+the elements in the class TOC. Note that the plugin includes some default 
 rules to control the spacing around the ``<details>`` elements that contain 
 TOCs for inherited attributes.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
+        'python': ('https://docs.python.org/3', None),
         'sphinx': ('https://www.sphinx-doc.org/', None),
 }
 autodoc_default_options = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = "~=3.6"
 requires = [
   'sphinx>=3.0',
   'docutils',
+  'more_itertools',
 ]
 classifiers = [
   'Programming Language :: Python :: 3',
@@ -22,6 +23,7 @@ classifiers = [
 tests = [
   'pytest',
   'pytest-cov',
+  'parametrize_from_file',
   'coveralls',
 ]
 docs = [

--- a/tests/test_section.nt
+++ b/tests/test_section.nt
@@ -1,0 +1,66 @@
+test_section_predicate:
+  # These predicates are evaluated in the context of the `MockObj` class 
+  # defined in the test script.
+  -
+    id: section
+    section:
+      > class MockSection(Section):
+      >     pass
+
+    expected:
+      - __init__
+      - data_attr
+      - method
+      - _private_data_attr
+      - _private_method
+      - InnerClass
+  -
+    id: section-exclude-str
+    section:
+      > class MockSection(Section):
+      >     exclude_pattern = '_'
+
+    expected:
+      - data_attr
+      - method
+      - InnerClass
+  -
+    id: section-exclude-list
+    section:
+      > class MockSection(Section):
+      >     exclude_pattern = ['_', 'Inner']
+
+    expected:
+      - data_attr
+      - method
+  -
+    id: public-methods
+    section: MockSection = PublicMethods
+    expected:
+      - __init__
+      - method
+  -
+    id: public-methods-without-dunders
+    section: MockSection = PublicMethodsWithoutDunders
+    expected:
+      - method
+  -
+    id: private-methods
+    section: MockSection = PrivateMethods
+    expected:
+      - _private_method
+  -
+    id: public-data-attrs
+    section: MockSection = PublicDataAttrs
+    expected:
+      - data_attr
+  -
+    id: private-data-attrs
+    section: MockSection = PrivateDataAttrs
+    expected:
+      - _private_data_attr
+  -
+    id: inner-classes
+    section: MockSection = InnerClasses
+    expected:
+      - InnerClass

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -27,7 +27,7 @@ def test_ExcludeSection1():
     cls = ExcludeSection1('state', 'cls')
 
     for key, item in names.items():
-        assert item == cls.check_for_pattern(key)
+        assert item == cls.exclude_if_match(cls.exclude_pattern, key)
 
 
 def test_ExcludeSection2():
@@ -43,4 +43,4 @@ def test_ExcludeSection2():
 
     cls = ExcludeSection2('state', 'cls')
     for key, item in names.items():
-        assert item == cls.check_for_pattern(key)
+        assert item == cls.exclude_if_match(cls.exclude_pattern, key)

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -16,6 +16,12 @@ class ExcludeSection2(autoclasstoc.Section):
     exclude_pattern = ['__', 'on']
 
 
+class ExcludeSection3(ExcludeSection2):
+
+    def predicate(self, name, attr, meta):
+        return not self.exclude_if_match(self.exclude_pattern, name)
+
+
 def test_ExcludeSection1():
     names = {
         '__init__': True,
@@ -44,3 +50,18 @@ def test_ExcludeSection2():
     cls = ExcludeSection2('state', 'cls')
     for key, item in names.items():
         assert item == cls.exclude_if_match(cls.exclude_pattern, key)
+
+
+def test_ExcludeSection3():
+    names = {
+        '__init__': True,
+        '__len__': True,
+        'foo': False,
+        'bar': False,
+        't__t': True,
+        'on_off': True,
+        'out': False
+    }
+    cls = ExcludeSection3('state', 'cls')
+    for key, item in names.items():
+        assert not item == cls.predicate(key, 'attr', 'meta')

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -22,6 +22,11 @@ class ExcludeSection3(ExcludeSection2):
         return not self.exclude_if_match(self.exclude_pattern, name)
 
 
+class ExcludeSection4(autoclasstoc.Section):
+    key = 'dummy-section-2'
+    title = "Dummy Section 2:"
+
+
 def test_ExcludeSection1():
     names = {
         '__init__': True,
@@ -65,3 +70,18 @@ def test_ExcludeSection3():
     cls = ExcludeSection3('state', 'cls')
     for key, item in names.items():
         assert not item == cls.predicate(key, 'attr', 'meta')
+
+
+def test_ExcludeSection4():
+    names = {
+        '__init__': True,
+        '__len__': True,
+        'foo': False,
+        'bar': False,
+        't__t': True,
+        'on_off': True,
+        'out': False
+    }
+    cls = ExcludeSection4('state', 'cls')
+    for key, item in names.items():
+        assert False == cls.exclude_if_match(cls.exclude_pattern, key)

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -84,4 +84,4 @@ def test_ExcludeSection4():
     }
     cls = ExcludeSection4('state', 'cls')
     for key, item in names.items():
-        assert False == cls.exclude_if_match(cls.exclude_pattern, key)
+        assert None == cls.exclude_if_match(cls.exclude_pattern, key)

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import pytest
+import autoclasstoc
+
+
+class ExcludeSection1(autoclasstoc.Section):
+    key = 'dummy-section-1'
+    title = "Dummy Section 1:"
+    exclude_pattern = '__'
+
+
+class ExcludeSection2(autoclasstoc.Section):
+    key = 'dummy-section-2'
+    title = "Dummy Section 2:"
+    exclude_pattern = ['__', 'on']
+
+
+def test_ExcludeSection1():
+    names = {
+        '__init__': True,
+        '__len__': True,
+        'foo': False,
+        'bar': False,
+        't__t': True
+    }
+    cls = ExcludeSection1('state', 'cls')
+
+    for key, item in names.items():
+        assert item == cls.check_for_pattern(key)
+
+
+def test_ExcludeSection2():
+    names = {
+        '__init__': True,
+        '__len__': True,
+        'foo': False,
+        'bar': False,
+        't__t': True,
+        'on_off': True,
+        'out': False
+    }
+
+    cls = ExcludeSection2('state', 'cls')
+    for key, item in names.items():
+        assert item == cls.check_for_pattern(key)


### PR DESCRIPTION
I added a `exclude_pattern` attribute to `Section` and also a new method `check_for_pattern(name)` that returns true if the `name` has any of the defined patterns. This function is then used with `and` in all `SectionSubClass.predicate()` methods.

In addition, I added a `PublicMethodWithoutDunders(PublicMethods)` class that excludes dunders. Also, I added a example in the documentation.

The last two commits of this MR handle autopep8 corrections in the py files and double spaces in the rst file, respectively. I can drop them if not wanted.

Deals with content of #16 