### PR TITLE
Reference inherited members to the parent's members

### DIFF
--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -365,7 +365,6 @@ def is_public(name):
     Specifically, a name is public if it either doesn't start with an 
     underscore.
     """
-    name = name.split('.')[-1]
     return not name.startswith('_')
 
 
@@ -385,7 +384,6 @@ def is_special(name):
 
     Such names typically have special meaning to Python, e.g. :meth:`__init__`.
     """
-    name = name.split('.')[-1]
     return name.startswith('__') and name.endswith('__')
 
 

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -365,6 +365,7 @@ def is_public(name):
     Specifically, a name is public if it either doesn't start with an 
     underscore.
     """
+    name = name.split('.')[-1]
     return not name.startswith('_')
 
 
@@ -384,6 +385,7 @@ def is_special(name):
 
     Such names typically have special meaning to Python, e.g. :meth:`__init__`.
     """
+    name = name.split('.')[-1]
     return name.startswith('__') and name.endswith('__')
 
 

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -137,9 +137,9 @@ def make_links(state, attrs):
     directive.
     """
     def fullname(name: str, attr):
-        if not hasattr(attr, '__qualname__') or not hasattr(attr, '__module__'):
+        if not hasattr(attr, '__module__') or not hasattr(attr, '__qualname__'):
             return name
-        return '~' + getattr(attr, '__module__', name) + '.' + getattr(attr, '__qualname__', name)
+        return f'~{attr.__module__}.{attr.__qualname__}'
 
     assert attrs
     return nodes_from_rst(state, [

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -139,7 +139,7 @@ def make_links(state, attrs):
     def qualname(name: str, attr):
         if not hasattr(attr, '__qualname__') or not hasattr(attr, '__module__'):
             return name
-        return getattr(attr, '__module__', name) + '.' + getattr(attr, '__qualname__', name)
+        return '~' + getattr(attr, '__module__', name) + '.' + getattr(attr, '__qualname__', name)
 
     assert attrs
     return nodes_from_rst(state, [

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -136,11 +136,16 @@ def make_links(state, attrs):
     More specifically, the links are made using the :rst:dir:`autosummary` 
     directive.
     """
+    def qualname(name: str, attr):
+        if not hasattr(attr, '__qualname__') or not hasattr(attr, '__module__'):
+            return name
+        return getattr(attr, '__module__', name) + '.' + getattr(attr, '__qualname__', name)
+
     assert attrs
     return nodes_from_rst(state, [
         '.. autosummary::',
         '',
-        *[f'    {x}' for x in attrs],
+        *[f'    {qualname(name, attr)}' for name, attr in attrs.items()],
     ])
 
 

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -136,7 +136,7 @@ def make_links(state, attrs):
     More specifically, the links are made using the :rst:dir:`autosummary` 
     directive.
     """
-    def qualname(name: str, attr):
+    def fullname(name: str, attr):
         if not hasattr(attr, '__qualname__') or not hasattr(attr, '__module__'):
             return name
         return '~' + getattr(attr, '__module__', name) + '.' + getattr(attr, '__qualname__', name)
@@ -145,7 +145,7 @@ def make_links(state, attrs):
     return nodes_from_rst(state, [
         '.. autosummary::',
         '',
-        *[f'    {qualname(name, attr)}' for name, attr in attrs.items()],
+        *[f'    {fullname(name, attr)}' for name, attr in attrs.items()],
     ])
 
 


### PR DESCRIPTION
### Description

This PR attempts to address issue #14.

In order to move the inherited members to the parent class rather than putting everything in the inherited class, I use the full qualified name of the attributes inspired by https://stackoverflow.com/a/2020083/18728919.

And I append a `~` before the full qualified name to display a short name in the TOC.

### Side effect

When the parent class is not documented, inherited members in the TOC will become non-clickable, even if the inherited class includes the inherited members, because by default it redirects to the parent class. A possible solution is to introduce a configure variable to let the users decide where they would like to place inherited members.