### PR TITLE
Relaxes constraint for supported Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 readme = "README.rst"
 dynamic = ["version", "description"]
-requires-python = ">=3.6,<3.11"
+requires-python = ">=3.6"
 classifiers = [
   'Programming Language :: Python :: 3',
 ]


### PR DESCRIPTION
you reminded me that i haven't had updated my autoclasstoc dependency for a while. beside it being a fast-moving-target at the time, i'm using poetry and i'st very strict with version constraints (this is what it's good at), i can elaborate if needed, but this gives an impression:

```
SolverProblemError

  The current project's Python requirement (>=3.7,<4.0) is not compatible with some of the required packages Python requirement:
    - autoclasstoc requires Python >=3.6,<3.11, so it will not be satisfied for Python >=3.11,<4.0
```

and there are certainly many thinkable scenarios where such constraint is an obstacle while it's always easier to ask forgiveness than to ask permission.

shall i also drop support for Python 3.6 in this PR?

note: i'm planning further non-functional changes while i'm at it, but a release with this solved obviously would help me a lot.