### PR TITLE
Changes GHA workflow trigger to pull request

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -1,6 +1,6 @@
 name: Test and release
 
-on: push
+on: pull_request
 jobs:
 
   test:
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # Make sure the whole repository history is present, so that 
+          # Make sure the whole repository history is present, so that
           # python-semantic-release can decide if a new release is needed.
           fetch-depth: 0
 


### PR DESCRIPTION
b/c the workflow requires a token that is not available when triggered on a forked repository and thus always fails.

the part where the workflow combines a release with a successful test run is frightening indeed.