### PR TITLE
Use full qualified name to link the parent class

### DIFF
--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -122,7 +122,7 @@ def make_inherited_details(state, parent, open_by_default=False):
     """
     from .nodes import details, details_summary
     s = details_summary()
-    s += strip_p(nodes_from_rst(state, f"Inherited from :py:class:`{parent.__qualname__}`"))
+    s += strip_p(nodes_from_rst(state, f"Inherited from :py:class:`~{parent.__module__}.{parent.__qualname__}`"))
 
     d = details(open_by_default)
     d += s

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -62,7 +62,13 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
           :members:
           :special-members:
           :private-members:
-          :inherited-members:
+
+          .. autoclasstoc::
+ 
+       .. autoclass:: parent.parent.Parent
+          :members:
+          :special-members:
+          :private-members:
 
           .. autoclasstoc::
           

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -62,13 +62,7 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
           :members:
           :special-members:
           :private-members:
-
-          .. autoclasstoc::
- 
-       .. autoclass:: basic_example.Parent
-          :members:
-          :special-members:
-          :private-members:
+          :inherited-members:
 
           .. autoclasstoc::
           

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -65,7 +65,7 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
 
           .. autoclasstoc::
  
-       .. autoclass:: parent.parent.Parent
+       .. autoclass:: basic_example.Parent
           :members:
           :special-members:
           :private-members:


### PR DESCRIPTION
### Issue

In the **Inherited from `Parent`** section, by default, the `Parent` class is referenced by **:py:class:`{parent.__qualname__}`"**, which may not correct when the `Parent` class is in another module rather in the same module with the inherited class.
https://github.com/kalekundert/autoclasstoc/blob/59f94545f4ae9d3ac304da093401a94c5d93c933/autoclasstoc/utils.py#L119-L129

For demonstration, I moved the `Parent` class to `parent.parent.Parent`, rather than the `basic_example.Parent` in a [test](https://github.com/haiiliin/autoclasstoc/tree/test-original) branch, the output is shown in https://autoclasstoc-test.readthedocs.io/en/test-original/basic_usage.html#basic_example.Example, you can see `Parent` is no longer clickable.

### Solution

To solve the problem, I use the full name of the `Parent` and use `~` to shorten the class name.
```python
def make_inherited_details(state, parent, open_by_default=False):
    """
    Make a collapsible node to contain information about inherited attributes.
    """
    from .nodes import details, details_summary
    s = details_summary()
    s += strip_p(nodes_from_rst(state, f"Inherited from :py:class:`~{parent.__module__}.{parent.__qualname__}`"))

    d = details(open_by_default)
    d += s
    return d
```

### Output

The corresponding documentation for this change can be found at https://autoclasstoc-test.readthedocs.io/en/test-modified/basic_usage.html#basic_example.Example, now `Parent` is clickable.
