### PR TITLE
Reference inherited attributes to the parent class

### DIFF
--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -126,7 +126,7 @@ class Section:
                 continue
 
             d = self._make_inherited_details(parent)
-            d += self._make_links(attrs)
+            d += self._make_links(attrs, parent=parent)
             wrapper += d
 
         return [wrapper]
@@ -181,7 +181,7 @@ class Section:
         """
         return utils.make_rubric(self.title)
 
-    def _make_links(self, attrs):
+    def _make_links(self, attrs, parent=None):
         """
         Make a link to the full documentation for each attribute.
 
@@ -192,8 +192,9 @@ class Section:
         Arguments:
             attrs (dict): A dictionary of attributes, in the same format as 
                 ``__dict__``.
+            parent (type): The class that the attributes were inherited from.
         """
-        return utils.make_links(self.state, attrs)
+        return utils.make_links(self.state, attrs, parent)
 
     def _make_inherited_details(self, parent):
         """

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -181,7 +181,7 @@ class Section:
         """
         return utils.make_rubric(self.title)
 
-    def _make_links(self, attrs, cls=None):
+    def _make_links(self, attrs, cls):
         """
         Make a link to the full documentation for each attribute.
 

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -116,7 +116,7 @@ class Section:
         wrapper += self._make_rubric()
 
         if attrs:
-            wrapper += self._make_links(attrs)
+            wrapper += self._make_links(attrs, self.cls)
 
         if not self.include_inherited:
             return [wrapper]
@@ -126,7 +126,7 @@ class Section:
                 continue
 
             d = self._make_inherited_details(parent)
-            d += self._make_links(attrs, parent=parent)
+            d += self._make_links(attrs, parent)
             wrapper += d
 
         return [wrapper]
@@ -181,7 +181,7 @@ class Section:
         """
         return utils.make_rubric(self.title)
 
-    def _make_links(self, attrs, parent=None):
+    def _make_links(self, attrs, cls=None):
         """
         Make a link to the full documentation for each attribute.
 
@@ -192,9 +192,9 @@ class Section:
         Arguments:
             attrs (dict): A dictionary of attributes, in the same format as 
                 ``__dict__``.
-            parent (type): The class that the attributes were inherited from.
+            cls (type): The class that the attributes belong to.
         """
-        return utils.make_links(self.state, attrs, parent)
+        return utils.make_links(self.state, attrs, cls)
 
     def _make_inherited_details(self, parent):
         """

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -129,7 +129,7 @@ def make_inherited_details(state, parent, open_by_default=False):
     return d
 
 
-def make_links(state, attrs):
+def make_links(state, attrs, parent=None):
     """
     Make links to the given class attributes.
 
@@ -138,7 +138,7 @@ def make_links(state, attrs):
     """
     def fullname(name: str, attr):
         if not hasattr(attr, '__module__') or not hasattr(attr, '__qualname__'):
-            return name
+            return name if parent is None else f"~{parent.__module__}.{parent.__qualname__}.{name}"
         return f'~{attr.__module__}.{attr.__qualname__}'
 
     assert attrs

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -122,7 +122,7 @@ def make_inherited_details(state, parent, open_by_default=False):
     """
     from .nodes import details, details_summary
     s = details_summary()
-    s += strip_p(nodes_from_rst(state, f"Inherited from :py:class:`{parent.__qualname__}`"))
+    s += strip_p(nodes_from_rst(state, f"Inherited from :py:class:`~{parent.__module__}.{parent.__qualname__}`"))
 
     d = details(open_by_default)
     d += s

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -129,7 +129,7 @@ def make_inherited_details(state, parent, open_by_default=False):
     return d
 
 
-def make_links(state, attrs, parent=None):
+def make_links(state, attrs, cls=None):
     """
     Make links to the given class attributes.
 
@@ -138,7 +138,7 @@ def make_links(state, attrs, parent=None):
     """
     def fullname(name: str, attr):
         if not hasattr(attr, '__module__') or not hasattr(attr, '__qualname__'):
-            return name if parent is None else f"~{parent.__module__}.{parent.__qualname__}.{name}"
+            return name if cls is None else f"~{cls.__module__}.{cls.__qualname__}.{name}"
         return f'~{attr.__module__}.{attr.__qualname__}'
 
     assert attrs

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -129,23 +129,18 @@ def make_inherited_details(state, parent, open_by_default=False):
     return d
 
 
-def make_links(state, attrs, cls=None):
+def make_links(state, attrs, cls):
     """
     Make links to the given class attributes.
 
     More specifically, the links are made using the :rst:dir:`autosummary` 
     directive.
     """
-    def fullname(name: str, attr):
-        if not hasattr(attr, '__module__') or not hasattr(attr, '__qualname__'):
-            return name if cls is None else f"~{cls.__module__}.{cls.__qualname__}.{name}"
-        return f'~{attr.__module__}.{attr.__qualname__}'
-
     assert attrs
     return nodes_from_rst(state, [
         '.. autosummary::',
         '',
-        *[f'    {fullname(name, attr)}' for name, attr in attrs.items()],
+        *[f'    ~{cls.__module__}.{cls.__qualname__}.{x}' for x in attrs],
     ])
 
 

--- a/docs/basic_example.py
+++ b/docs/basic_example.py
@@ -1,5 +1,5 @@
 class Parent:
-    #: This is a public attributes
+    #: This is a public attribute
     public_attribute = 1
     #: This is a private attribute
     _private_attribute = 2

--- a/docs/basic_example.py
+++ b/docs/basic_example.py
@@ -1,4 +1,8 @@
 class Parent:
+    #: This is a public attributes
+    public_attribute = 1
+    #: This is a private attribute
+    _private_attribute = 2
 
     def inherited_method(self):
         """Duis lacus metus, euismod ut viverra sit amet, pulvinar sed urna."""

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -62,7 +62,13 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
           :members:
           :special-members:
           :private-members:
-          :inherited-members:
+
+          .. autoclasstoc::
+ 
+       .. autoclass:: parent.parent.Parent
+          :members:
+          :special-members:
+          :private-members:
 
           .. autoclasstoc::
           

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -65,7 +65,7 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
 
           .. autoclasstoc::
  
-       .. autoclass:: parent.parent.Parent
+       .. autoclass:: basic_example.Parent
           :members:
           :special-members:
           :private-members:


### PR DESCRIPTION
# 1. Update documentation

In #22, the link in the TOC has been changed to the `Parent` class members, but the documentation is not changed, so I updated the documentation by adding the `Parent` class and removing the `:inherited-members:`.

The corresponding documentation can be found at https://autoclasstoc-test.readthedocs.io/en/latest/basic_usage.html#basic_example.Example

# 2. Fixes an issue to reference inherited attributes

## Issue

This pull request updates the documentation and fixes the issue to reference inherited attributes to the parent's attributes introduced in #22.

In #22, the inherited members in the TOC will link to the `Parent` class using `~{attr.__module__}.{attr.__qualname__}`
https://github.com/kalekundert/autoclasstoc/blob/59f94545f4ae9d3ac304da093401a94c5d93c933/autoclasstoc/utils.py#L132-L149
But this is not correct for attributes since there are no `__module__` and `__qualname__` in attributes. This will make inherited public/private attributes in the TOC not clickable.

## Solution

To solve this problem, this pull request adds a new argument `cls` to the `make_links` function, and uses `~{cls.__module__}.{cls.__qualname__}.{name}` to link the inherited attributes/methods. 
```python
def make_links(state, attrs, cls):
    """
    Make links to the given class attributes.

    More specifically, the links are made using the :rst:dir:`autosummary` 
    directive.
    """
    assert attrs
    return nodes_from_rst(state, [
        '.. autosummary::',
        '',
        *[f'    ~{cls.__module__}.{cls.__qualname__}.{x}' for x in attrs],
    ])
```

## Output

The corresponding documentation can be found at https://autoclasstoc-test.readthedocs.io/en/test-attributes/basic_usage.html#basic_example.Example

# 3. Use full qualified name to link the parent class

## Issue

In the **Inherited from `Parent`** section, by default, the `Parent` class is referenced by **:py:class:`{parent.__qualname__}`"**, which may not correct when the `Parent` class is in another module rather in the same module with the inherited class.
https://github.com/kalekundert/autoclasstoc/blob/59f94545f4ae9d3ac304da093401a94c5d93c933/autoclasstoc/utils.py#L119-L129

For demonstration, I moved the `Parent` class to `parent.parent.Parent`, rather than the `basic_example.Parent` in a [test](https://github.com/haiiliin/autoclasstoc/tree/test-original) branch, the output is shown in https://autoclasstoc-test.readthedocs.io/en/test-original/basic_usage.html#basic_example.Example, you can see `Parent` is no longer clickable.

## Solution

To solve the problem, I use the full name of the `Parent` and use `~` to shorten the class name.
```python
def make_inherited_details(state, parent, open_by_default=False):
    """
    Make a collapsible node to contain information about inherited attributes.
    """
    from .nodes import details, details_summary
    s = details_summary()
    s += strip_p(nodes_from_rst(state, f"Inherited from :py:class:`~{parent.__module__}.{parent.__qualname__}`"))

    d = details(open_by_default)
    d += s
    return d
```

## Output

The corresponding documentation for this change can be found at https://autoclasstoc-test.readthedocs.io/en/test-modified/basic_usage.html#basic_example.Example, now `Parent` is clickable.