### PR TITLE
Support LaTeX build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/autoclasstoc/nodes.py
+++ b/autoclasstoc/nodes.py
@@ -4,6 +4,7 @@ possible to create collapsible content in HTML.
 """
 
 from docutils.nodes import General, Element, TextElement
+from sphinx.writers.latex import LaTeXTranslator
 
 
 class details(General, Element):
@@ -14,8 +15,8 @@ class details(General, Element):
     compatible with non-HTML output formats.
     """
 
-    def __init__(self, open_by_default=False):
-        super().__init__()
+    def __init__(self, rawsource='', *children, open_by_default=False, **attributes):
+        super().__init__(rawsource, *children, **attributes)
         self['open'] = open_by_default
 
     def visit_html(visitor, node):
@@ -55,6 +56,21 @@ class details_summary(General, TextElement):
     html = visit_html, depart_html
 
 
+class AutoClassTocLatexTranslator(LaTeXTranslator):
+
+    def visit_details(self, node):
+        pass
+
+    def depart_details(self, node):
+        pass
+
+    def visit_details_summary(self, node):
+        pass
+
+    def depart_details_summary(self, node):
+        self.body.append('\n')
+
+
 def setup(app):
     """
     Configure Sphinx to use the `details` and `details_summary` nodes.
@@ -67,3 +83,4 @@ def setup(app):
         details_summary,
         html=details_summary.html,
     )
+    app.set_translator('latex', AutoClassTocLatexTranslator, override=True)

--- a/autoclasstoc/nodes.py
+++ b/autoclasstoc/nodes.py
@@ -57,6 +57,7 @@ class details_summary(General, TextElement):
 
 
 class AutoClassTocLatexTranslator(LaTeXTranslator):
+    """A custom LaTeX translator that incorporates the `details` and `details_summary` nodes."""
 
     def visit_details(self, node):
         pass

--- a/autoclasstoc/nodes.py
+++ b/autoclasstoc/nodes.py
@@ -56,7 +56,7 @@ class details_summary(General, TextElement):
     html = visit_html, depart_html
 
 
-class AutoClassTocLaTexTranslator(LaTeXTranslator):
+class AutoClassTocLaTeXTranslator(LaTeXTranslator):
     """A custom LaTeX translator that incorporates the `details` and `details_summary` nodes."""
 
     def visit_details(self, node):
@@ -84,4 +84,4 @@ def setup(app):
         details_summary,
         html=details_summary.html,
     )
-    app.set_translator('latex', AutoClassTocLaTexTranslator, override=True)
+    app.set_translator('latex', AutoClassTocLaTeXTranslator, override=True)

--- a/autoclasstoc/nodes.py
+++ b/autoclasstoc/nodes.py
@@ -4,7 +4,6 @@ possible to create collapsible content in HTML.
 """
 
 from docutils.nodes import General, Element, TextElement
-from sphinx.writers.latex import LaTeXTranslator
 
 
 class details(General, Element):
@@ -33,10 +32,17 @@ class details(General, Element):
 
         visitor.body.append(f"<{' '.join(parts)}>")
 
+    def visit_latex(visitor, node):
+        pass
+
     def depart_html(visitor, node):
         visitor.body.append('</details>')
 
+    def depart_latex(visitor, node):
+        pass
+
     html = visit_html, depart_html
+    latex = visit_latex, depart_latex
 
 
 class details_summary(General, TextElement):
@@ -50,26 +56,17 @@ class details_summary(General, TextElement):
     def visit_html(visitor, node):
         visitor.body.append('<summary>')
 
+    def visit_latex(visitor, node):
+        visitor.body.append('\n')
+
     def depart_html(visitor, node):
         visitor.body.append('</summary>')
 
+    def depart_latex(visitor, node):
+        visitor.body.append('\n')
+
     html = visit_html, depart_html
-
-
-class AutoClassTocLaTeXTranslator(LaTeXTranslator):
-    """A custom LaTeX translator that incorporates the `details` and `details_summary` nodes."""
-
-    def visit_details(self, node):
-        pass
-
-    def depart_details(self, node):
-        pass
-
-    def visit_details_summary(self, node):
-        self.body.append('\n')
-
-    def depart_details_summary(self, node):
-        self.body.append('\n')
+    latex = visit_latex, depart_latex
 
 
 def setup(app):
@@ -79,9 +76,10 @@ def setup(app):
     app.add_node(
         details,
         html=details.html,
+        latex=details.latex,
     )
     app.add_node(
         details_summary,
         html=details_summary.html,
+        latex=details_summary.latex,
     )
-    app.set_translator('latex', AutoClassTocLaTeXTranslator, override=True)

--- a/autoclasstoc/nodes.py
+++ b/autoclasstoc/nodes.py
@@ -66,7 +66,7 @@ class AutoClassTocLaTexTranslator(LaTeXTranslator):
         pass
 
     def visit_details_summary(self, node):
-        pass
+        self.body.append('\n')
 
     def depart_details_summary(self, node):
         self.body.append('\n')

--- a/autoclasstoc/nodes.py
+++ b/autoclasstoc/nodes.py
@@ -56,7 +56,7 @@ class details_summary(General, TextElement):
     html = visit_html, depart_html
 
 
-class AutoClassTocLatexTranslator(LaTeXTranslator):
+class AutoClassTocLaTexTranslator(LaTeXTranslator):
     """A custom LaTeX translator that incorporates the `details` and `details_summary` nodes."""
 
     def visit_details(self, node):
@@ -84,4 +84,4 @@ def setup(app):
         details_summary,
         html=details_summary.html,
     )
-    app.set_translator('latex', AutoClassTocLatexTranslator, override=True)
+    app.set_translator('latex', AutoClassTocLaTexTranslator, override=True)

--- a/autoclasstoc/plugin.py
+++ b/autoclasstoc/plugin.py
@@ -29,6 +29,8 @@ class AutoClassToc(SphinxDirective):
                 self.options.get('sections') or
                 self.config.autoclasstoc_sections,
                 exclude=self.options.get('exclude-sections'),
+                include_inherited=self.config.autoclasstoc_include_inherited,
+                exclude_pattern=self.config.autoclasstoc_exclude_pattern,
             )
             return utils.make_toc(self.state, cls, sections)
 
@@ -62,6 +64,8 @@ def setup(app):
     ]
 
     app.add_config_value('autoclasstoc_sections', default_sections, 'env')
+    app.add_config_value('autoclasstoc_include_inherited', None, 'env')
+    app.add_config_value('autoclasstoc_exclude_pattern', None, 'env')
     app.add_directive('autoclasstoc', AutoClassToc)
     app.connect('config-inited', load_static_assets)
 

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -124,7 +124,7 @@ def make_inherited_details(state, parent, open_by_default=False):
     s = details_summary()
     s += strip_p(nodes_from_rst(state, f"Inherited from :py:class:`{get_cls_xref(parent)}`"))
 
-    d = details(open_by_default)
+    d = details(open_by_default=open_by_default)
     d += s
     return d
 

--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -47,7 +47,7 @@ def load_class(mod_name, cls_name):
     return mod, cls
 
 
-def pick_sections(sections, exclude=None):
+def pick_sections(sections, exclude=None, include_inherited=None, exclude_pattern=None):
     """
     Determine which sections to include in the class TOC.
 
@@ -57,17 +57,24 @@ def pick_sections(sections, exclude=None):
     classes.  All names will be converted to classes in the return value.
     """
 
+    def _set_section_options(section):
+        if include_inherited is not None:
+            section.include_inherited = include_inherited
+        if exclude_pattern is not None:
+            section.exclude_pattern = exclude_pattern
+        return section
+
     def _section_from_anything(x):
         from .sections import Section, SECTIONS
 
         if isinstance(x, str):
             try:
-                return SECTIONS[x]
+                return _set_section_options(SECTIONS[x])
             except KeyError:
                 raise ConfigError(f"no autoclasstoc section with key {x!r}")
 
         if isclass(x) and issubclass(x, Section):
-            return x
+            return _set_section_options(x)
 
         raise ConfigError(f"cannot interpret {x!r} as a section")
 

--- a/docs/syntax/sphinx.rst
+++ b/docs/syntax/sphinx.rst
@@ -37,3 +37,19 @@ The following setting can be defined in ``conf.py``:
             'private-attrs',
             'private-methods',
     ]
+
+.. confval:: autoclasstoc_include_inherited
+
+  Whether or not to include inherited attributes in this section.  The default value is
+  ``None``.
+
+  This configuration will override the ``include-inherited`` attribute of the
+  :class:`autoclasstoc.Section` class and its subclasses when it is not ``None``.
+
+.. confval:: autoclasstoc_exclude_pattern
+
+  A regular expression (or list of regular expressions) matching attribute
+  names that should be excluded from this section.
+
+  This configuration will override the ``exclude-pattern`` attribute of the
+  :class:`autoclasstoc.Section` class and its subclasses when it is not ``None``.


### PR DESCRIPTION
## Description

`autoclasstoc` seems to only work on html build, this pull request tries to support the LaTeX build.

For example, with the following simple usage:
```rst
.. autoclass:: pandas.DataFrame
   :members:

   .. autoclasstoc::
```
An exception occurs:
```
Exception occurred:
  File "C:\Users\Hailin\AppData\Local\Programs\Python\Python310\lib\site-packages\sphinx\util\nodes.py", line 636, in _new_copy
    newnode = self.__class__(self.rawsource, **self.attributes)
TypeError: details.__init__() got an unexpected keyword argument 'ids'
```
This is because the signature of the constructor of the `details` node is not compatible with the `Element` node:
https://github.com/kalekundert/autoclasstoc/blob/1e209b22ffd958fbdff394c9db2d7aadeddd0ea1/autoclasstoc/nodes.py#L9-L19
Whereas the signature of `Element`'s constructor is:
```python
def __init__(self, rawsource='', *children, **attributes):
```
Thus the signature of the `details`'s constructor is updated to be compatible with `Element`:
```python
def __init__(self, rawsource='', *children, open_by_default=False, **attributes):
```
The argument `open_by_default` is now key-value-only argument.

To further configure the LaTeX builder for the `nodes` and `details_summary` nodes, we have to define a custom LaTeX translator:
```python
class AutoClassTocLaTexTranslator(LaTeXTranslator):
    """A custom LaTeX translator that incorporates the `details` and `details_summary` nodes."""

    def visit_details(self, node):
        pass

    def depart_details(self, node):
        pass

    def visit_details_summary(self, node):
        pass

    def depart_details_summary(self, node):
        self.body.append('\n')
```
Because I don't find an environment in LaTeX to insert collapsible content, the `details` implementation is left blank. A new line should be inserted after every `details_summary` node in LaTeX so that they won't be in the same line.