### PR TITLE
Automatically load the autosummary extension

### DIFF
--- a/autoclasstoc/plugin.py
+++ b/autoclasstoc/plugin.py
@@ -61,7 +61,7 @@ def setup(app):
         'private-methods'
     ]
 
-    app.setup_extension("sphinx.ext.autosummary")
+    app.setup_extension('sphinx.ext.autosummary')
     app.add_config_value('autoclasstoc_sections', default_sections, 'env')
     app.add_directive('autoclasstoc', AutoClassToc)
     app.connect('config-inited', load_static_assets)

--- a/autoclasstoc/plugin.py
+++ b/autoclasstoc/plugin.py
@@ -63,6 +63,7 @@ def setup(app):
 
     app.add_config_value('autoclasstoc_sections', default_sections, 'env')
     app.add_directive('autoclasstoc', AutoClassToc)
+    app.setup_extension("sphinx.ext.autosummary")
     app.connect('config-inited', load_static_assets)
 
     return {

--- a/autoclasstoc/plugin.py
+++ b/autoclasstoc/plugin.py
@@ -61,9 +61,9 @@ def setup(app):
         'private-methods'
     ]
 
+    app.setup_extension("sphinx.ext.autosummary")
     app.add_config_value('autoclasstoc_sections', default_sections, 'env')
     app.add_directive('autoclasstoc', AutoClassToc)
-    app.setup_extension("sphinx.ext.autosummary")
     app.connect('config-inited', load_static_assets)
 
     return {

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -8,7 +8,8 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
 
     $ pip install autoclasstoc
 
-2. Enable the ``autoclasstoc``  The snippet below also enables :ext:`autodoc` and 
+2. Enable the ``autoclasstoc`` extension for your Sphinx project. 
+   The snippet below also enables :ext:`autodoc` and 
    :ext:`viewcode` to demonstrate a typical configuration, but neither of these 
    extensions are required:
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -8,9 +8,7 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
 
     $ pip install autoclasstoc
 
-2. Enable the ``autoclasstoc`` and :ext:`autosummary` extensions for your 
-   Sphinx project.  The latter is required because ``autoclasstoc`` uses it to 
-   create the TOC.  The snippet below also enables :ext:`autodoc` and 
+2. Enable the ``autoclasstoc``  The snippet below also enables :ext:`autodoc` and 
    :ext:`viewcode` to demonstrate a typical configuration, but neither of these 
    extensions are required:
 
@@ -21,7 +19,6 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
               ...
               'autoclasstoc',
               'sphinx.ext.autodoc',
-              'sphinx.ext.autosummary',
               'sphinx.ext.viewcode',
               ...
       ]

--- a/tests/test_autoclasstoc.nt
+++ b/tests/test_autoclasstoc.nt
@@ -177,7 +177,6 @@ test_autoclasstoc:
       conf.py:
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         > autoclasstoc_sections = []
 
@@ -210,7 +209,6 @@ test_autoclasstoc:
       conf.py:
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         > autoclasstoc_sections = [
         >     'public-methods',
@@ -244,7 +242,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         >
         > class CustomMethods(PublicMethods):
@@ -292,7 +289,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         >
         > class CustomMethods(PublicMethods):
@@ -345,7 +341,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         >
         > class CustomMethods(PublicMethods):
@@ -397,7 +392,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         >
         > class CustomMethods(PublicMethods):
@@ -449,7 +443,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         >
         > class PublicMethods(PublicMethods):
@@ -489,7 +482,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         >
         > class OpenPublicMethods(PublicMethods):
@@ -529,7 +521,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         >
         > class CustomSection(Section):
@@ -559,7 +550,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         >
         > class CustomSection(Section):
@@ -589,7 +579,6 @@ test_autoclasstoc:
         >
         > extensions = [
         >         'autoclasstoc',
-        >         'sphinx.ext.autosummary',
         > ]
         > autoclasstoc_sections = [
         >     None,

--- a/tests/test_autoclasstoc.py
+++ b/tests/test_autoclasstoc.py
@@ -20,7 +20,6 @@ def test_autoclasstoc(tmp_files, expected, forbidden, stderr, monkeypatch):
         conf_py.write_text("""\
 extensions = [
         'autoclasstoc',
-        'sphinx.ext.autosummary',
 ]
 """)
 


### PR DESCRIPTION
## Description

The `autoclasstoc` extension requires the `sphinx.ext.autosummary` extension but it is required to be added in the `extensions` manually. This PR automatically load the `sphinx.ext.autosummary` extension when setting up the `autoclasstoc` extension.

The `sphinx.ext.autosummary` extension should be loaded automatically because in the common usage, the `sphinx.ext.autosummary` is not directly used but required by `autoclasstoc`. The `sphinx.ext.autodoc` extension, however, is not this case, and it should be loaded explicitly.