### PR TITLE
Support `autoclasstoc` option for `autoclass`

### DIFF
--- a/autoclasstoc/plugin.py
+++ b/autoclasstoc/plugin.py
@@ -1,3 +1,5 @@
+from docutils.parsers.rst import directives
+from sphinx.ext.autodoc import ClassDocumenter
 from sphinx.util.docutils import SphinxDirective
 from . import utils, __version__, ConfigError
 
@@ -50,6 +52,16 @@ def load_static_assets(app, config):
     app.add_css_file('autoclasstoc.css')
 
 
+class AutoClassTocClassDocumenter(ClassDocumenter):
+    option_spec = ClassDocumenter.option_spec.copy()
+    option_spec['autoclasstoc'] = directives.flag
+
+    def add_content(self, more_content):
+        super().add_content(more_content)
+        if 'autoclasstoc' in self.options:
+            self.add_line('.. autoclasstoc::', self.get_sourcename())
+
+
 def setup(app):
     from . import nodes
     nodes.setup(app)
@@ -64,6 +76,7 @@ def setup(app):
     app.setup_extension('sphinx.ext.autosummary')
     app.add_config_value('autoclasstoc_sections', default_sections, 'env')
     app.add_directive('autoclasstoc', AutoClassToc)
+    app.add_autodocumenter(AutoClassTocClassDocumenter, override=True)
     app.connect('config-inited', load_static_assets)
 
     return {

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -44,8 +44,21 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
           'exclude-members': '__weakref__',
       }
    
-3. Use the :rst:dir:`autoclasstoc` directive to add a TOC to a class.  Follow 
-   the link for a full description of the directive, but typical usage is 
+3. Use the :rst:dir:`autoclasstoc` directive or the `autoclasstoc` option for
+   :rst:dir:`autoclass` directive to add a TOC to a class.
+
+   .. code-block:: rst
+
+      .. autoclass:: my_module.MyClass
+         :members:
+
+         .. autoclasstoc::
+
+      .. autoclass:: my_module.MyClass
+         :members:
+         :autoclasstoc:
+
+   Follow the link for a full description of the directive, but typical usage is
    pretty straight-forward.  For example, consider the ``Example`` class in the 
    following snippet:
 
@@ -67,6 +80,7 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
           :members:
           :special-members:
           :private-members:
-
-          .. autoclasstoc::
+          :autoclasstoc:
           
+   The :rst:dir:`autoclasstoc` directive can also be accessed via the
+   `autoclasstoc` option to :rst:dir:`autoclass`:

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -81,6 +81,4 @@ Follow these steps to start using :rst:dir:`autoclasstoc` in your project:
           :special-members:
           :private-members:
           :autoclasstoc:
-          
-   The :rst:dir:`autoclasstoc` directive can also be accessed via the
-   `autoclasstoc` option to :rst:dir:`autoclass`:
+

--- a/tests/test_autoclasstoc.nt
+++ b/tests/test_autoclasstoc.nt
@@ -117,6 +117,25 @@ test_autoclasstoc:
         //div[contains(@class,'autoclasstoc')]/p: Public Methods
         //div[contains(@class,'autoclasstoc')]//td[last()]/p: Method docstring
   -
+    id: directive-options-autoclass-option
+    tmp_files:
+      index.rst:
+        > .. autoclass:: mock_project.Class
+        >   :autoclasstoc:
+
+      mock_project.py:
+        > class Class:
+        >     "Class docstring"
+        >   
+        >     def method(self):
+        >         "Method docstring"
+
+    expected:
+      index.html:
+        //div[contains(@class,'autoclasstoc')]/p: Public Methods
+        //div[contains(@class,'autoclasstoc')]//td[last()]/p: Method docstring
+
+  -
     id: directive-options-infer-class-from-py-domain
     tmp_files:
       index.rst:


### PR DESCRIPTION
## Description

This PR adds support for a custom option `autoclasstoc` for the `autoclass` directive which is simpler to use, for example, the code
```rst
.. autoclass:: my_module.my_class
    :members:
    :autoclasstoc:
```
is equivalent to:
```rst
.. autoclass:: my_module.my_class
    :members:
    
    .. autoclasstoc::
```