### PR TITLE
Update autosummary cross-reference syntax

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,1 +1,0 @@
-module.exports = {extends: ['@commitlint/config-conventional']}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
           - '3.12'
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
@@ -32,11 +32,12 @@ jobs:
         run: |
           tox
       - name: Store coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.python-version }}
           path: .coverage.*
-          if-no-files-found: ignore
+          if-no-files-found: error
+          include-hidden-files: true
 
   coverage:
     name: Report coverage
@@ -44,31 +45,35 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: |
           python -m pip install --upgrade pip
           python -m pip install coverage[toml]
-      - uses: actions/download-artifact@v3
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data-*
       
       - name: Combine coverage data
         run: |
-          python -m coverage combine
+          python -m coverage combine coverage-data-*
           python -m coverage html --skip-covered --skip-empty
           python -m coverage xml
           python -m coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload HTML coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report-html
           path: htmlcov
 
       - name: Upload Codecov report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,9 @@
+[general]
+ignore=title-must-not-contain-word,body-is-missing,body-trailing-whitespace
+contrib=contrib-title-conventional-commits
+ignore-merge-commits=true
+ignore-revert-commits=true
+
+[contrib-title-conventional-commits]
+types=chore,docs,feat,fix,perf,refactor,style,test,wip
+

--- a/autoclasstoc/plugin.py
+++ b/autoclasstoc/plugin.py
@@ -23,14 +23,15 @@ class AutoClassToc(SphinxDirective):
         """
         try:
             qual_name = self.arguments[0] if self.arguments else None
-            mod_name, cls_name = utils.pick_class(qual_name, self.env)
+            mod_name, cls_name, xref_factory = \
+                    utils.pick_class(qual_name, self.env)
             mod, cls = utils.load_class(mod_name, cls_name)
             sections = utils.pick_sections(
                 self.options.get('sections') or
                 self.config.autoclasstoc_sections,
                 exclude=self.options.get('exclude-sections'),
             )
-            return utils.make_toc(self.state, cls, sections)
+            return utils.make_toc(self.state, cls, xref_factory, sections)
 
         except ConfigError as err:
             raise self.error(str(err))

--- a/autoclasstoc/sections.py
+++ b/autoclasstoc/sections.py
@@ -58,7 +58,7 @@ class Section:
     excluded from this section.
     """
 
-    def __init__(self, state, cls):
+    def __init__(self, state, cls, xref_factory):
         """
         Create a section for a specific class.
 
@@ -67,10 +67,20 @@ class Section:
                 associated with the :rst:dir:`autoclasstoc` directive.  This 
                 can be used to evaluate restructured text markup using 
                 `nodes_from_rst()`.  
+
             cls (type): The class to make the TOC section for.
+
+            xref_factory: A function that, given a class, returns the string 
+                that should be used to make a cross-reference to that class.  
+                These strings, unfortunately, are context-dependent.  If 
+                :rst:dir:`autoclasstoc` is used within a class, 
+                cross-references must not include the module that the class is 
+                defined in.  (:rst:dir:`autosummary` requires this for some 
+                reason).  Otherwise, fully-qualified names must be used.
         """
         self.state = state
         self.cls = cls
+        self.xref_factory = xref_factory
 
     def __init_subclass__(cls):
         """
@@ -154,7 +164,7 @@ class Section:
             return False
 
         for section_cls in always_iterable(self.exclude_section):
-            section = section_cls(self.state, self.cls)
+            section = section_cls(self.state, self.cls, self.xref_factory)
             if section.predicate(name, attr, meta):
                 return False
 
@@ -192,7 +202,7 @@ class Section:
                 ``__dict__``.
             cls (type): The class that the attributes belong to.
         """
-        return utils.make_links(self.state, attrs, cls)
+        return utils.make_links(self.state, attrs, cls, self.xref_factory)
 
     def _make_inherited_details(self, parent):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ tests = [
   'lxml',
   'coverage[toml]',
   'coverage_enable_subprocess',
+  'tox',
 ]
 docs = [
   'sphinx>=3.1',
@@ -63,8 +64,8 @@ exclude_lines = [
 version_variable = 'autoclasstoc/__init__.py:__version__'
 build_command = 'python -m pip install flit && flit build'
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["F"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]

--- a/tests/test_autoclasstoc.nt
+++ b/tests/test_autoclasstoc.nt
@@ -918,6 +918,16 @@ test_autoclasstoc:
         //dl[@class='py attribute']/dt/@id: mock_project.Parent.parent_data_attr
   -
     id: link-parent-data-attr-annotation-only
+
+    # This test fails because the parent attribute is incorrectly included in 
+    # the child class's TOC.  However, this is due to the fact that `autodoc` 
+    # manually adds the parent class annotations to the the child class's 
+    # `__annotations__` dictionary.  This specifically happens in
+    # `sphinx.ext.autodoc.AttributeDocumenter.update_annotations()`.  Until 
+    # this behavior is changed, there's no way for `autoclasstoc` to get this 
+    # right.
+    marks: xfail
+
     tmp_files:
       index.rst:
         > .. toctree::
@@ -969,17 +979,3 @@ test_autoclasstoc:
       parent.html:
         //dl[@class='py class']/dt/@id: mock_project.Parent
         //dl[@class='py attribute']/dt/@id: mock_project.Parent.parent_data_attr
-
-    # This test case triggers the following warning:
-    #   
-    #   WARNING: autosummary: failed to import mock_project.Child.parent_data_attr.
-    #
-    # The documentation is built correctly, but presumably the warning is 
-    # issued because the attribute is only annotated; it doesn't actually 
-    # exist.  This is a case that autodoc needs to detect and handle more 
-    # gracefully.  We can't avoid the warning without getting rid of the 
-    # links altogether, so instead we have to just ignore the usual stderr 
-    # tests by matching anything.
-    stderr: 
-      - .*
-

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -76,7 +76,7 @@ def test_section_predicate(section, obj, expected):
             if k not in EmptyObj.__dict__
     }
     section_cls = with_autoclasstoc.exec(section, get='MockSection')
-    section = section_cls('state', 'cls')
+    section = section_cls('state', 'cls', 'xref_factory')
     hits = autoclasstoc.utils.filter_attrs(attrs, section.predicate)
     assert set(hits) == set(expected)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = 
-    py37-sphinx{3,4,5},coverage
-    py{38,39}-sphinx{3,4,5,6,7},coverage
-    py{310,311,312}-sphinx{3,4,5,6,7,8},coverage
+    py37-sphinx{3,4,5}
+    py{38,39}-sphinx{3,4,5,6,7}
+    py{310,311,312}-sphinx{3,4,5,6,7,8}
 isolated_build = True
 
 [testenv]
@@ -26,14 +26,6 @@ deps =
     sphinx7: sphinx==7.*
     sphinx8: sphinx==8.*
 commands = python -m coverage run -m pytest -x
-
-[testenv:coverage]
-basepython = python3.10
-depends = py{37,38,39,310,311,312}-sphinx{3,4,5,6,7,8}
-commands = 
-    python -m coverage combine
-    python -m coverage report
-parallel_show_output = true
 
 [gh-actions]
 python = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py{37,38,39,310,311}-sphinx{3,4,5},coverage
+envlist = 
+    py37-sphinx{3,4,5},coverage
+    py{38,39}-sphinx{3,4,5,6,7},coverage
+    py{310,311,312}-sphinx{3,4,5,6,7,8},coverage
 isolated_build = True
 
 [testenv]
@@ -7,13 +10,26 @@ extras = tests
 deps =
     sphinx3: sphinx==3.*
     sphinx3: sphinx-jinja2-compat
+    sphinx3: sphinxcontrib-applehelp<=1.0.4
+    sphinx3: sphinxcontrib-devhelp<=1.0.2
+    sphinx3: sphinxcontrib-htmlhelp<=2.0.1
+    sphinx3: sphinxcontrib-qthelp<=1.0.3
+    sphinx3: sphinxcontrib-serializinghtml<=1.1.5
     sphinx4: sphinx==4.*
+    sphinx4: sphinxcontrib-applehelp<=1.0.4
+    sphinx4: sphinxcontrib-devhelp<=1.0.2
+    sphinx4: sphinxcontrib-htmlhelp<=2.0.1
+    sphinx4: sphinxcontrib-qthelp<=1.0.3
+    sphinx4: sphinxcontrib-serializinghtml<=1.1.5
     sphinx5: sphinx==5.*
-commands = python -m coverage run -m pytest
+    sphinx6: sphinx==6.*
+    sphinx7: sphinx==7.*
+    sphinx8: sphinx==8.*
+commands = python -m coverage run -m pytest -x
 
 [testenv:coverage]
 basepython = python3.10
-depends = py{37,38,39,310,311}-sphinx{3,4,5}
+depends = py{37,38,39,310,311,312}-sphinx{3,4,5,6,7,8}
 commands = 
     python -m coverage combine
     python -m coverage report
@@ -26,3 +42,4 @@ python =
   3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312


### PR DESCRIPTION
This is meant to fix #39.

New versions of autosummary make it much more difficult to specify cross references.  Before, it was always correct to use fully-qualified names. Now, if the autosummary directive is contained within a class, its cross references must not start with the name of the module that that class is defined in.  In other words, the cross references must be relative, not absolute, in this case.  If the autosummary directive is not contained within a class, then fully-qualified names are still required.  This adds a bunch of annoying complexity to the code.